### PR TITLE
Make section headers sticky on mobile

### DIFF
--- a/src/components/PartsSection.tsx
+++ b/src/components/PartsSection.tsx
@@ -17,9 +17,7 @@ export const PartsSection = ({ category, parts, onPartClick }: PartsSectionProps
   useEffect(() => {
     const updateOffset = () => {
       const nav = document.getElementById("main-nav");
-      const isMobile = window.innerWidth < 1024;
-      const gap = isMobile ? 78 : 75;
-      setOffset((nav?.offsetHeight || 0) + gap);
+      setOffset((nav?.offsetHeight || 0) + 5);
     };
     updateOffset();
     window.addEventListener("resize", updateOffset);


### PR DESCRIPTION
## Summary
- keep section headers sticky at all screen sizes

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6884e1d3b4248320a5a8672abfc32d1b