### PR TITLE
Add sirv for DO deployment

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "vite build",
     "build:dev": "vite build --mode development",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "start": "sirv dist --single --port $PORT"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.0",
@@ -59,7 +60,8 @@
     "tailwind-merge": "^2.5.2",
     "tailwindcss-animate": "^1.0.7",
     "vaul": "^0.9.3",
-    "zod": "^3.23.8"
+    "zod": "^3.23.8",
+    "sirv-cli": "^2.0.2"
   },
   "devDependencies": {
     "@eslint/js": "^9.9.0",


### PR DESCRIPTION
## Summary
- add a `start` script for DigitalOcean App Platform
- include `sirv-cli` to serve the built files

## Testing
- `npm run build` *(fails: `vite` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6885240a5a4083208067fb997bbccf0e