### PR TITLE
Add Info modals to PartsBoard

### DIFF
--- a/src/components/InfoModal.tsx
+++ b/src/components/InfoModal.tsx
@@ -1,0 +1,38 @@
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+
+interface InfoModalProps {
+  title: string;
+  isOpen: boolean;
+  onClose: () => void;
+  children: React.ReactNode;
+}
+
+export const InfoModal = ({ title, isOpen, onClose, children }: InfoModalProps) => {
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === "Escape") {
+      onClose();
+    }
+  };
+
+  return (
+    <Dialog open={isOpen} onOpenChange={onClose}>
+      <DialogContent
+        className="max-w-[95vw] sm:max-w-[500px] z-50 bg-background/70 backdrop-blur-md border border-white rounded-lg"
+        onKeyDown={handleKeyDown}
+      >
+        <DialogHeader>
+          <DialogTitle className="text-xl font-semibold">{title}</DialogTitle>
+        </DialogHeader>
+        <div className="py-4 space-y-4 text-foreground text-sm">{children}</div>
+        <div className="flex justify-end pt-2">
+          <Button onClick={onClose} className="bg-white text-black hover:bg-white/90">
+            Ok
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default InfoModal;

--- a/src/pages/PartsBoard.tsx
+++ b/src/pages/PartsBoard.tsx
@@ -61,12 +61,12 @@ export const PartsBoard = () => {
     >
       <div className="max-w-8xl mx-auto p-6">
         <div className="mb-8 text-center">
+          <h1 className="text-3xl font-bold text-foreground mb-2">
+            Who's In Charge?
+          </h1>
           <h2 className="text-2xl font-bold text-foreground mb-2">
-            Choose a Part to Journal With
+            An Internal Family Systems Journaling Site
           </h2>
-          <p className="text-muted-foreground">
-            Click on any part below to explore what it wants to express today.
-          </p>
           <div className="mt-6 flex flex-col sm:flex-row justify-center gap-4">
             <button
               onClick={() => setIsIFSOpen(true)}
@@ -125,6 +125,6 @@ export const PartsBoard = () => {
       >
         {instructions}
       </InfoModal>
-    </div>
+    </div >
   );
 };

--- a/src/pages/PartsBoard.tsx
+++ b/src/pages/PartsBoard.tsx
@@ -3,11 +3,14 @@ import { useScrollToTop } from "@/hooks/use-scroll-to-top";
 import { parts, Part } from "@/data/parts";
 import { PartsSection } from "@/components/PartsSection";
 import { JournalModal } from "@/components/JournalModal";
+import InfoModal from "@/components/InfoModal";
 
 export const PartsBoard = () => {
   useScrollToTop();
   const [selectedPart, setSelectedPart] = useState<Part | null>(null);
   const [isModalOpen, setIsModalOpen] = useState(false);
+  const [isIFSOpen, setIsIFSOpen] = useState(false);
+  const [isInstructionsOpen, setIsInstructionsOpen] = useState(false);
 
   const handlePartClick = (part: Part) => {
     setSelectedPart(part);
@@ -23,6 +26,34 @@ export const PartsBoard = () => {
   const firefighters = parts.filter(part => part.cat === "firefighter");
   const exiles = parts.filter(part => part.cat === "exile");
 
+  const ifsDescription = (
+    <>
+      <p>
+        Internal Family Systems (IFS) views the mind as a collection of
+        sub-personalities, or "parts," each with its own perspective and
+        feelings. These parts often develop roles to protect us from pain, and
+        they can sometimes clash with one another.
+      </p>
+      <p>
+        The goal of IFS is to help you connect with your calm, curious Self so
+        that all parts can be heard and work together in harmony.
+      </p>
+    </>
+  );
+
+  const instructions = (
+    <>
+      <p>
+        Select a part below to open a journal modal and write what that part is
+        feeling or wanting to say.
+      </p>
+      <p>
+        Your entries are saved in your browser. Visit the Parts Info page to
+        read about each part type and review your writing in Journal Entries.
+      </p>
+    </>
+  );
+
   return (
     <div
       className="min-h-screen bg-background"
@@ -36,6 +67,22 @@ export const PartsBoard = () => {
           <p className="text-muted-foreground">
             Click on any part below to explore what it wants to express today.
           </p>
+          <div className="mt-6 flex flex-col sm:flex-row justify-center gap-4">
+            <button
+              onClick={() => setIsIFSOpen(true)}
+              className="flex items-center justify-between gap-2 p-6 border border-white rounded-lg bg-background hover:bg-muted/50 transition-colors"
+            >
+              <span>What Is IFS?</span>
+              <span role="img" aria-label="candle">🕯️</span>
+            </button>
+            <button
+              onClick={() => setIsInstructionsOpen(true)}
+              className="flex items-center justify-between gap-2 p-6 border border-white rounded-lg bg-background hover:bg-muted/50 transition-colors"
+            >
+              <span>Instructions</span>
+              <span role="img" aria-label="abacus">🧮</span>
+            </button>
+          </div>
         </div>
 
         <div className="flex flex-col lg:flex-row gap-6">
@@ -64,6 +111,20 @@ export const PartsBoard = () => {
         isOpen={isModalOpen}
         onClose={handleCloseModal}
       />
+      <InfoModal
+        title="What Is IFS?"
+        isOpen={isIFSOpen}
+        onClose={() => setIsIFSOpen(false)}
+      >
+        {ifsDescription}
+      </InfoModal>
+      <InfoModal
+        title="Instructions"
+        isOpen={isInstructionsOpen}
+        onClose={() => setIsInstructionsOpen(false)}
+      >
+        {instructions}
+      </InfoModal>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- add reusable `InfoModal` component for modal dialogs
- update `PartsBoard` with a new info section and instructions modal

## Testing
- `npx eslint .` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6885b028e7f0832084e91628e11dcf31