### PR TITLE
Move text to data and extend instructions

### DIFF
--- a/src/components/DisclaimerModal.tsx
+++ b/src/components/DisclaimerModal.tsx
@@ -8,7 +8,7 @@ import {
   DialogFooter,
 } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
-import { disclaimerText } from "@/data/content";
+import { disclaimerModalText } from "@/data/content";
 
 const ACK_KEY = "ifs-journal-disclaimer-ack";
 
@@ -52,7 +52,7 @@ export const DisclaimerModal = () => {
             Disclaimer
           </DialogTitle>
           <DialogDescription asChild>
-            <div className="space-y-4 pt-2 text-left">{disclaimerText}</div>
+            <div className="space-y-4 pt-2 text-left">{disclaimerModalText}</div>
           </DialogDescription>
         </DialogHeader>
         <DialogFooter className="sm:justify-end">

--- a/src/components/DisclaimerModal.tsx
+++ b/src/components/DisclaimerModal.tsx
@@ -8,6 +8,7 @@ import {
   DialogFooter,
 } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
+import { disclaimerText } from "@/data/content";
 
 const ACK_KEY = "ifs-journal-disclaimer-ack";
 
@@ -51,21 +52,7 @@ export const DisclaimerModal = () => {
             Disclaimer
           </DialogTitle>
           <DialogDescription asChild>
-            <div className="space-y-4 pt-2 text-left">
-              <p>
-                For maximum privacy, none of your journal entries are stored in the
-                cloud. The data stays in your browser's Local Storage, which means
-                that your entries will not transfer from one browser to the next.
-                If you use an Incognito or private window and close it, or
-                delete your Local Storage, you WILL LOSE YOUR ENTRIES!
-              </p>
-              <p>
-                It is recommended that you use this site on a device that only you can
-                access. You can find your entries in Local Storage &gt; ifs-journal-entries
-                in your browser. If you wish to save, edit, or delete your entries, you
-                can do so there. Click "Acknowledge" to hide this message in the future.
-              </p>
-            </div>
+            <div className="space-y-4 pt-2 text-left">{disclaimerText}</div>
           </DialogDescription>
         </DialogHeader>
         <DialogFooter className="sm:justify-end">

--- a/src/components/InfoModal.tsx
+++ b/src/components/InfoModal.tsx
@@ -27,7 +27,7 @@ export const InfoModal = ({ title, isOpen, onClose, children }: InfoModalProps) 
         <div className="py-4 space-y-4 text-foreground text-sm">{children}</div>
         <div className="flex justify-end pt-2">
           <Button onClick={onClose} className="bg-white text-black hover:bg-white/90">
-            Ok
+            OK
           </Button>
         </div>
       </DialogContent>

--- a/src/data/content.tsx
+++ b/src/data/content.tsx
@@ -34,7 +34,14 @@ export const disclaimerText = (
       For maximum privacy, none of your journal entries are stored in the cloud. The data stays in your browser's Local Storage, which means that your entries will not transfer from one browser to the next. If you use an Incognito or private window and close it, or delete your Local Storage, you WILL LOSE YOUR ENTRIES!
     </p>
     <p>
-      It is recommended that you use this site on a device that only you can access. You can find your entries in Local Storage &gt; ifs-journal-entries in your browser. If you wish to save, edit, or delete your entries, you can do so there. Click "Acknowledge" to hide this message in the future.
+      It is recommended that you use this site on a device that only you can access. You can find your entries in Local Storage &gt; ifs-journal-entries in your browser. If you wish to save, edit, or delete your entries, you can do so there.
     </p>
+  </>
+);
+
+export const disclaimerModalText = (
+  <>
+    {disclaimerText}
+    <p>Click "Acknowledge" to hide this message in the future.</p>
   </>
 );

--- a/src/data/content.tsx
+++ b/src/data/content.tsx
@@ -1,0 +1,40 @@
+import React from "react";
+
+export const ifsDescription = (
+  <>
+    <p>
+      Internal Family Systems (IFS) is a psychotherapy approach developed by Richard C. Schwartz in the 1980s. The model views the mind as an inner family made up of distinct “parts,” each with its own perspective and feelings. These parts interact with one another much like family members, sometimes cooperating and sometimes competing for control of the person’s behavior.
+    </p>
+    <p>
+      IFS groups parts into categories based on how they try to protect us. “Managers” work to keep daily life functioning smoothly and prevent painful emotions from surfacing. When distress does break through, “Firefighters” leap in to douse the intensity, often through impulsive or distracting behaviors. Hidden beneath these protectors are “Exiles,” vulnerable parts that carry burdens of trauma, shame, or fear.
+    </p>
+    <p>
+      At the heart of the system is the Self—a calm, compassionate state that embodies curiosity, confidence, and clarity. Therapy aims to help individuals access this Self so it can lead the internal family. When the Self is in charge, protective parts can relax and wounded parts can release the burdens they carry.
+    </p>
+    <p>
+      IFS therapy involves “unblending” from strong emotions, listening to each part’s positive intent, and fostering a trusting relationship between the Self and the parts. By doing so, people often experience more inner harmony and relief from symptoms related to trauma, anxiety, and other mental health concerns. The approach has grown beyond its clinical roots and is now applied in coaching, spirituality, and personal growth contexts.
+    </p>
+  </>
+);
+
+export const instructions = (
+  <>
+    <p>
+      Select a part below to open a journal modal and write what that part is feeling or wanting to say.
+    </p>
+    <p>
+      Your entries are saved in your browser. Visit the Parts Info page to read about each part type and review your writing in Journal Entries.
+    </p>
+  </>
+);
+
+export const disclaimerText = (
+  <>
+    <p>
+      For maximum privacy, none of your journal entries are stored in the cloud. The data stays in your browser's Local Storage, which means that your entries will not transfer from one browser to the next. If you use an Incognito or private window and close it, or delete your Local Storage, you WILL LOSE YOUR ENTRIES!
+    </p>
+    <p>
+      It is recommended that you use this site on a device that only you can access. You can find your entries in Local Storage &gt; ifs-journal-entries in your browser. If you wish to save, edit, or delete your entries, you can do so there. Click "Acknowledge" to hide this message in the future.
+    </p>
+  </>
+);

--- a/src/pages/PartsBoard.tsx
+++ b/src/pages/PartsBoard.tsx
@@ -4,6 +4,7 @@ import { parts, Part } from "@/data/parts";
 import { PartsSection } from "@/components/PartsSection";
 import { JournalModal } from "@/components/JournalModal";
 import InfoModal from "@/components/InfoModal";
+import { ifsDescription, instructions, disclaimerText } from "@/data/content";
 
 export const PartsBoard = () => {
   useScrollToTop();
@@ -26,33 +27,6 @@ export const PartsBoard = () => {
   const firefighters = parts.filter(part => part.cat === "firefighter");
   const exiles = parts.filter(part => part.cat === "exile");
 
-  const ifsDescription = (
-    <>
-      <p>
-        Internal Family Systems (IFS) views the mind as a collection of
-        sub-personalities, or "parts," each with its own perspective and
-        feelings. These parts often develop roles to protect us from pain, and
-        they can sometimes clash with one another.
-      </p>
-      <p>
-        The goal of IFS is to help you connect with your calm, curious Self so
-        that all parts can be heard and work together in harmony.
-      </p>
-    </>
-  );
-
-  const instructions = (
-    <>
-      <p>
-        Select a part below to open a journal modal and write what that part is
-        feeling or wanting to say.
-      </p>
-      <p>
-        Your entries are saved in your browser. Visit the Parts Info page to
-        read about each part type and review your writing in Journal Entries.
-      </p>
-    </>
-  );
 
   return (
     <div
@@ -124,6 +98,10 @@ export const PartsBoard = () => {
         onClose={() => setIsInstructionsOpen(false)}
       >
         {instructions}
+        <div className="pt-4 space-y-2 text-left">
+          <h3 className="text-lg font-semibold">Disclaimer</h3>
+          <div className="space-y-4 pt-2">{disclaimerText}</div>
+        </div>
       </InfoModal>
     </div >
   );


### PR DESCRIPTION
## Summary
- centralize IFS, instructions and disclaimer text in `/src/data/content.tsx`
- load new text in `PartsBoard` and include disclaimer section
- reference data text from `DisclaimerModal`
- expand the IFS explanation to four paragraphs

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6886395813e08320a002d67eceabb456