### PR TITLE
Implement multi-section journaling

### DIFF
--- a/src/components/EntryModal.tsx
+++ b/src/components/EntryModal.tsx
@@ -28,14 +28,39 @@ export const EntryModal = ({ entry, isOpen, onClose }: EntryModalProps) => {
           </DialogTitle>
         </DialogHeader>
 
-        <div className="py-4">
-          <div className="bg-muted/50 rounded-lg p-4">
-            <p className="text-foreground whitespace-pre-wrap leading-relaxed">
-              {entry.text}
-            </p>
+        <div className="py-4 space-y-4">
+          <div>
+            <h4 className="text-sm font-medium mb-1">
+              What's this part feeling right now? What does it want to say?
+            </h4>
+            <div className="bg-muted/50 rounded-lg p-4 min-h-[1.5rem]">
+              <p className="text-foreground whitespace-pre-wrap leading-relaxed">
+                {entry.feeling || entry.text || ""}
+              </p>
+            </div>
           </div>
 
-          <div className="mt-4 text-xs text-muted-foreground">
+          <div>
+            <h4 className="text-sm font-medium mb-1">What does this part need?</h4>
+            <div className="bg-muted/50 rounded-lg p-4 min-h-[1.5rem]">
+              <p className="text-foreground whitespace-pre-wrap leading-relaxed">
+                {entry.need || ""}
+              </p>
+            </div>
+          </div>
+
+          <div>
+            <h4 className="text-sm font-medium mb-1">
+              How can you help this part? What does it need from you (your Higher Self)?
+            </h4>
+            <div className="bg-muted/50 rounded-lg p-4 min-h-[1.5rem]">
+              <p className="text-foreground whitespace-pre-wrap leading-relaxed">
+                {entry.help || ""}
+              </p>
+            </div>
+          </div>
+
+          <div className="text-xs text-muted-foreground">
             {new Date(entry.timestamp).toLocaleString()}
           </div>
         </div>

--- a/src/components/JournalModal.tsx
+++ b/src/components/JournalModal.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from "react";
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
+import { Label } from "@/components/ui/label";
 import { Part } from "@/data/parts";
 import { saveEntry, getTodayString } from "@/utils/journal";
 import { useToast } from "@/hooks/use-toast";
@@ -13,17 +14,21 @@ interface JournalModalProps {
 }
 
 export const JournalModal = ({ part, isOpen, onClose }: JournalModalProps) => {
-  const [text, setText] = useState("");
+  const [feeling, setFeeling] = useState("");
+  const [need, setNeed] = useState("");
+  const [help, setHelp] = useState("");
   const { toast } = useToast();
 
   useEffect(() => {
     if (!isOpen) {
-      setText("");
+      setFeeling("");
+      setNeed("");
+      setHelp("");
     }
   }, [isOpen]);
 
   const handleSave = () => {
-    if (!part || !text.trim()) {
+    if (!part || !feeling.trim() && !need.trim() && !help.trim()) {
       onClose();
       return;
     }
@@ -32,7 +37,10 @@ export const JournalModal = ({ part, isOpen, onClose }: JournalModalProps) => {
       date: getTodayString(),
       part: part.id,
       partLabel: part.label,
-      text: text.trim(),
+      text: feeling.trim(),
+      feeling: feeling.trim(),
+      need: need.trim(),
+      help: help.trim(),
       timestamp: Date.now()
     };
 
@@ -71,13 +79,45 @@ export const JournalModal = ({ part, isOpen, onClose }: JournalModalProps) => {
         </DialogHeader>
 
         <div className="space-y-4 py-4">
-          <Textarea
-            placeholder="Add your journal entry here."
-            value={text}
-            onChange={(e) => setText(e.target.value)}
-            className="min-h-[120px] resize-none"
-            autoFocus
-          />
+          <div className="space-y-2">
+            <Label htmlFor="feeling" className="text-sm">
+              What's this part feeling right now? What does it want to say?
+            </Label>
+            <Textarea
+              id="feeling"
+              placeholder="Type here"
+              value={feeling}
+              onChange={(e) => setFeeling(e.target.value)}
+              className="min-h-[100px] resize-none"
+              autoFocus
+            />
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="need" className="text-sm">
+              What does this part need?
+            </Label>
+            <Textarea
+              id="need"
+              placeholder="Type here"
+              value={need}
+              onChange={(e) => setNeed(e.target.value)}
+              className="min-h-[100px] resize-none"
+            />
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="help" className="text-sm">
+              How can you help this part? What does it need from you (your Higher Self)?
+            </Label>
+            <Textarea
+              id="help"
+              placeholder="Type here"
+              value={help}
+              onChange={(e) => setHelp(e.target.value)}
+              className="min-h-[100px] resize-none"
+            />
+          </div>
         </div>
 
         <div className="flex justify-end space-x-2">

--- a/src/pages/JournalEntries.tsx
+++ b/src/pages/JournalEntries.tsx
@@ -109,7 +109,7 @@ export const JournalEntries = () => {
                               {entry.partLabel}
                             </h4>
                             <p className="text-sm text-muted-foreground mt-1 line-clamp-2">
-                              {entry.text}
+                              {entry.feeling || entry.text}
                             </p>
                           </div>
                           <div className="text-xs text-muted-foreground ml-4">

--- a/src/types/journal.ts
+++ b/src/types/journal.ts
@@ -2,7 +2,10 @@ export interface JournalEntry {
   date: string; // ISO date string (YYYY-MM-DD)
   part: string; // part ID
   partLabel: string; // part label for display
-  text: string;
+  text: string; // legacy field used for preview/snippets
+  feeling?: string; // what's this part feeling right now
+  need?: string; // what does this part need
+  help?: string; // how can the higher self help
   timestamp: number; // for sorting entries within a day
 }
 


### PR DESCRIPTION
## Summary
- extend journal entries data model with separate fields for the new prompts
- update JournalModal to display three stacked textareas with their prompts
- save the answers in the new fields
- show each section in EntryModal
- preview the first section in the entries list

## Testing
- `npm run lint` *(fails: cannot find package `@eslint/js`)*
- `npm run build` *(fails: `vite` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6886d28bb388832083575bd1f4fd34e4