### PR TITLE
Use feelings field for journal text

### DIFF
--- a/src/components/JournalModal.tsx
+++ b/src/components/JournalModal.tsx
@@ -37,7 +37,6 @@ export const JournalModal = ({ part, isOpen, onClose }: JournalModalProps) => {
       date: getTodayString(),
       part: part.id,
       partLabel: part.label,
-      text: feeling.trim(),
       feeling: feeling.trim(),
       need: need.trim(),
       help: help.trim(),

--- a/src/types/journal.ts
+++ b/src/types/journal.ts
@@ -2,7 +2,7 @@ export interface JournalEntry {
   date: string; // ISO date string (YYYY-MM-DD)
   part: string; // part ID
   partLabel: string; // part label for display
-  text: string; // legacy field used for preview/snippets
+  text?: string; // legacy field used for preview/snippets
   feeling?: string; // what is this part feeling right now
   need?: string; // what does this part need
   help?: string; // how can the higher self help


### PR DESCRIPTION
## Summary
- do not populate the `text` field when saving journal entries
- make the `text` field optional in the `JournalEntry` type

## Testing
- `npx tsc --noEmit`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6886e61c6ed88320b2d0eab8413aa0bd