### PR TITLE
Add journal export feature

### DIFF
--- a/src/components/ExportModal.tsx
+++ b/src/components/ExportModal.tsx
@@ -1,0 +1,39 @@
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+
+interface ExportModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onExportCSV: () => void;
+  onExportJSON: () => void;
+}
+
+export const ExportModal = ({ isOpen, onClose, onExportCSV, onExportJSON }: ExportModalProps) => {
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === "Escape") {
+      onClose();
+    }
+  };
+
+  return (
+    <Dialog open={isOpen} onOpenChange={onClose}>
+      <DialogContent
+        className="max-w-[95vw] sm:max-w-[400px] z-50 bg-background/70 backdrop-blur-md border border-white rounded-lg"
+        onKeyDown={handleKeyDown}
+      >
+        <DialogHeader>
+          <DialogTitle className="text-xl font-semibold">Export Entries</DialogTitle>
+        </DialogHeader>
+        <div className="space-y-4 py-2 text-center">
+          <p className="text-sm text-muted-foreground">Which format would you like to export?</p>
+          <div className="flex justify-center gap-4">
+            <Button onClick={onExportCSV}>CSV</Button>
+            <Button onClick={onExportJSON}>JSON</Button>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default ExportModal;

--- a/src/pages/JournalEntries.tsx
+++ b/src/pages/JournalEntries.tsx
@@ -1,9 +1,16 @@
 import { useState, useEffect } from "react";
 import { Link } from "react-router-dom";
 import { useScrollToTop } from "@/hooks/use-scroll-to-top";
-import { getEntries, groupEntriesByDate, formatDate } from "@/utils/journal";
+import {
+  getEntries,
+  groupEntriesByDate,
+  formatDate,
+  exportEntriesAsCSV,
+  exportEntriesAsJSON,
+} from "@/utils/journal";
 import { JournalEntry } from "@/types/journal";
 import { EntryModal } from "@/components/EntryModal";
+import { ExportModal } from "@/components/ExportModal";
 import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "@/components/ui/accordion";
 import { Button } from "@/components/ui/button";
 import { FileText, Calendar } from "lucide-react";
@@ -13,6 +20,7 @@ export const JournalEntries = () => {
   const [entries, setEntries] = useState<JournalEntry[]>([]);
   const [selectedEntry, setSelectedEntry] = useState<JournalEntry | null>(null);
   const [isModalOpen, setIsModalOpen] = useState(false);
+  const [isExportOpen, setIsExportOpen] = useState(false);
 
   useEffect(() => {
     const loadEntries = () => {
@@ -69,6 +77,16 @@ export const JournalEntries = () => {
     setEntries(sortedEntries);
   };
 
+  const handleExportCSV = () => {
+    exportEntriesAsCSV();
+    setIsExportOpen(false);
+  };
+
+  const handleExportJSON = () => {
+    exportEntriesAsJSON();
+    setIsExportOpen(false);
+  };
+
   const groupedEntries = groupEntriesByDate(entries);
   const sortedDates = Object.keys(groupedEntries).sort((a, b) => b.localeCompare(a));
 
@@ -106,6 +124,13 @@ export const JournalEntries = () => {
           <p className="text-muted-foreground">
             Explore your conversations with different parts over time.
           </p>
+          <Button
+            variant="outline"
+            className="mt-4"
+            onClick={() => setIsExportOpen(true)}
+          >
+            Export Your Entries 🪙
+          </Button>
         </div>
 
         <div className="space-y-4">
@@ -165,6 +190,12 @@ export const JournalEntries = () => {
         onClose={handleCloseModal}
         onEntryUpdate={handleEntryUpdate}
         onEntryDelete={handleEntryDelete}
+      />
+      <ExportModal
+        isOpen={isExportOpen}
+        onClose={() => setIsExportOpen(false)}
+        onExportCSV={handleExportCSV}
+        onExportJSON={handleExportJSON}
       />
     </div>
   );

--- a/src/utils/journal.ts
+++ b/src/utils/journal.ts
@@ -54,3 +54,67 @@ export const deleteEntry = (timestamp: number): void => {
 export const getTodayString = (): string => {
   return new Date().toISOString().split('T')[0];
 };
+
+export const entriesToCSV = (entries: JournalEntry[]): string => {
+  const headers = [
+    'date',
+    'part',
+    'partLabel',
+    'feeling',
+    'need',
+    'help',
+    'timestamp',
+  ];
+
+  const escape = (value: string | number) => {
+    const str = String(value ?? '');
+    if (str.includes('"') || str.includes(',') || str.includes('\n')) {
+      return `"${str.replace(/"/g, '""')}"`;
+    }
+    return str;
+  };
+
+  const rows = entries.map((e) =>
+    [
+      e.date,
+      e.part,
+      e.partLabel,
+      e.feeling || '',
+      e.need || '',
+      e.help || '',
+      e.timestamp,
+    ]
+      .map(escape)
+      .join(',')
+  );
+
+  return [headers.join(','), ...rows].join('\n');
+};
+
+const downloadTextFile = (
+  filename: string,
+  text: string,
+  type: string
+) => {
+  const blob = new Blob([text], { type });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = filename;
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  URL.revokeObjectURL(url);
+};
+
+export const exportEntriesAsCSV = (): void => {
+  const entries = getEntries();
+  const csv = entriesToCSV(entries);
+  downloadTextFile('journal_entries.csv', csv, 'text/csv');
+};
+
+export const exportEntriesAsJSON = (): void => {
+  const entries = getEntries();
+  const json = JSON.stringify(entries, null, 2);
+  downloadTextFile('journal_entries.json', json, 'application/json');
+};


### PR DESCRIPTION
## Summary
- add ExportModal component
- extend journal utilities with export helpers
- provide export functionality on journal entries page

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6888d55271c88320931b515851fb6b4b