### PR TITLE
Fix legacy journal export

### DIFF
--- a/src/utils/journal.ts
+++ b/src/utils/journal.ts
@@ -79,7 +79,7 @@ export const entriesToCSV = (entries: JournalEntry[]): string => {
       e.date,
       e.part,
       e.partLabel,
-      e.feeling || '',
+      e.feeling ?? e.text ?? '',
       e.need || '',
       e.help || '',
       e.timestamp,


### PR DESCRIPTION
## Summary
- handle old `text` field when exporting journal entries

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_688945ac6b6c83208aa23235925d8073